### PR TITLE
Fix raising error with empty `api` section

### DIFF
--- a/esphome_dashboard_api/__init__.py
+++ b/esphome_dashboard_api/__init__.py
@@ -104,14 +104,18 @@ class ESPHomeDashboardAPI:
 
         if not config:
             return None
-        print(config)
 
         api = config.get("api")
         # An empty `api:` section in yaml produces a null object in json
         if api is None:
             return None
 
-        return api.get("encryption", {}).get("key")
+        encryption = api.get("encryption")
+
+        if encryption is None:
+            return
+
+        return encryption.get("key")
 
     async def get_devices(self) -> Devices:
         """Get all devices."""

--- a/esphome_dashboard_api/__init__.py
+++ b/esphome_dashboard_api/__init__.py
@@ -104,8 +104,14 @@ class ESPHomeDashboardAPI:
 
         if not config:
             return None
+        print(config)
 
-        return config.get("api", {}).get("encryption", {}).get("key")
+        api = config.get("api")
+        # An empty `api:` section in yaml produces a null object in json
+        if api is None:
+            return None
+
+        return api.get("encryption", {}).get("key")
 
     async def get_devices(self) -> Devices:
         """Get all devices."""

--- a/esphome_dashboard_api/__init__.py
+++ b/esphome_dashboard_api/__init__.py
@@ -113,7 +113,7 @@ class ESPHomeDashboardAPI:
         encryption = api.get("encryption")
 
         if encryption is None:
-            return
+            return None
 
         return encryption.get("key")
 


### PR DESCRIPTION
```
2023-01-31 13:12:53.369 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/home/jesse/workspace/home-assistant/core/venv/bin/hass", line 33, in <module>
    sys.exit(load_entry_point('homeassistant', 'console_scripts', 'hass')())
  File "/home/jesse/workspace/home-assistant/core/homeassistant/__main__.py", line 214, in main
    exit_code = runner.run(runtime_conf)
  File "/home/jesse/workspace/home-assistant/core/homeassistant/runner.py", line 128, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/lib/python3.10/asyncio/base_events.py", line 636, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 603, in run_forever
    self._run_once()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 1898, in _run_once
    handle._run()
  File "/usr/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/jesse/workspace/home-assistant/core/venv/lib/python3.10/site-packages/aioesphomeapi/reconnect_logic.py", line 171, in _reconnect_loop
    await self._reconnect_once()
  File "/home/jesse/workspace/home-assistant/core/venv/lib/python3.10/site-packages/aioesphomeapi/reconnect_logic.py", line 166, in _reconnect_once
    await self._try_connect()
  File "/home/jesse/workspace/home-assistant/core/venv/lib/python3.10/site-packages/aioesphomeapi/reconnect_logic.py", line 124, in _try_connect
    await self._on_connect_error_cb(err)
  File "/home/jesse/workspace/home-assistant/core/homeassistant/components/esphome/__init__.py", line 367, in on_connect_error
    entry.async_start_reauth(hass)
  File "/home/jesse/workspace/home-assistant/core/homeassistant/config_entries.py", line 703, in async_start_reauth
    hass.async_create_task(
  File "/home/jesse/workspace/home-assistant/core/homeassistant/core.py", line 518, in async_create_task
    task = self.loop.create_task(target)
Traceback (most recent call last):
  File "/home/jesse/workspace/home-assistant/core/homeassistant/config_entries.py", line 798, in async_init
    flow, result = await task
  File "/home/jesse/workspace/home-assistant/core/homeassistant/config_entries.py", line 826, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data)
  File "/home/jesse/workspace/home-assistant/core/homeassistant/data_entry_flow.py", line 335, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/home/jesse/workspace/home-assistant/core/homeassistant/components/esphome/config_flow.py", line 95, in async_step_reauth
    return await self.async_step_reauth_confirm()
  File "/home/jesse/workspace/home-assistant/core/homeassistant/components/esphome/config_flow.py", line 103, in async_step_reauth_confirm
    if await self._retrieve_encryption_key_from_dashboard():
  File "/home/jesse/workspace/home-assistant/core/homeassistant/components/esphome/config_flow.py", line 375, in _retrieve_encryption_key_from_dashboard
    noise_psk = await dashboard.api.get_encryption_key(device["configuration"])
  File "/home/jesse/workspace/home-assistant/core/venv/lib/python3.10/site-packages/esphome_dashboard_api/__init__.py", line 109, in get_encryption_key
    return config.get("api", {}).get("encryption", {}).get("key")
AttributeError: 'NoneType' object has no attribute 'get'
```