### PR TITLE
Speed up processing websocket json with orjson

### DIFF
--- a/esphome_dashboard_api/__init__.py
+++ b/esphome_dashboard_api/__init__.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Callable, TypedDict
 
 import aiohttp
+import orjson
 
 
 class ConfiguredDevice(TypedDict):
@@ -69,7 +70,7 @@ class ESPHomeDashboardAPI:
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     return False
 
-                data = msg.json()
+                data = msg.json(loads=orjson.loads)
 
                 event = data.get("event")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=65.6", "wheel~=0.37.1"]
+requires = ["setuptools>=69.0.2", "wheel>=0.41.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,6 +14,7 @@ authors      = [
 requires-python = ">=3.4.0"
 dependencies = [
   "aiohttp",
+  "orjson"
 ]
 
 [project.urls]


### PR DESCRIPTION
I noticed the system started to lag a bit when I updated many devices at once. Profiling showed it was json decoding.

<img width="1365" alt="Screenshot 2023-12-04 at 4 56 40 PM" src="https://github.com/esphome/dashboard-api/assets/663432/4e9657e6-5f5d-40ad-8cd9-79357b200382">
